### PR TITLE
Fix contributes.configuration structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,28 +122,29 @@
                 "command": "extension.toggleCase.copyToggled",
                 "title": "Copy with Case Toggled between configured cases"
             }
-        ]
-    },
-    "configuration": {
-        "type": "object",
-        "title": "toggleCase configuration",
-        "properties": {
-            "toggleCase.includeDotInCurrentWord": {
-                "type": "boolean",
-                "default": "false",
-                "description": "When selecting current word, allow dots in current word (false by default)"
-            },
-            "toggleCase.case1": {
-                "type": "string",
-                "default": "kebab",
-                "description": "First case to toggle to/from (from/to second)"
-            },
-            "toggleCase.case2": {
-                "type": "string",
-                "default": "camel",
-                "description": "Second case to toggle to/from (from/to first)"
+        ],
+        "configuration": [
+            {
+                "title": "toggleCase configuration",
+                "properties": {
+                    "toggleCase.includeDotInCurrentWord": {
+                        "type": "boolean",
+                        "default": "false",
+                        "description": "When selecting current word, allow dots in current word (false by default)"
+                    },
+                    "toggleCase.case1": {
+                        "type": "string",
+                        "default": "kebab",
+                        "description": "First case to toggle to/from (from/to second)"
+                    },
+                    "toggleCase.case2": {
+                        "type": "string",
+                        "default": "camel",
+                        "description": "Second case to toggle to/from (from/to first)"
+                    }
+                }
             }
-        }
+        ]
     },
     "scripts": {
         "vscode:prepublish": "tsc -p ./",

--- a/src/toggle-case-commands.ts
+++ b/src/toggle-case-commands.ts
@@ -40,7 +40,7 @@ const notifyOrThrow = (message: string, doThrow = false): void => {
 }
 
 const toggleCase = (input: string, throwWhenInvalid = false): string | undefined => {
-    const { case1, case2 } = <ToggleConfiguration>(vscode.workspace.getConfiguration('togglecase') || { case1: '', case2: '' })
+    const { case1, case2 } = <ToggleConfiguration>(vscode.workspace.getConfiguration('toggleCase') || { case1: '', case2: '' })
     const notify = (message) => notifyOrThrow(message, throwWhenInvalid)
 
     let method;


### PR DESCRIPTION
`case1` and `case2` configuration options didn't seem to work correctly, so fixed the structure of package.json. Now, you can change these configuration options by GUI.

![image](https://user-images.githubusercontent.com/17942/61308356-1459cb80-a82b-11e9-99e3-da216f975fce.png)
https://code.visualstudio.com/api/references/contribution-points
